### PR TITLE
[FIXED JENKINS-22879] Fix Groovy classloading issue.

### DIFF
--- a/src/main/java/hudson/matrix/FilterScript.java
+++ b/src/main/java/hudson/matrix/FilterScript.java
@@ -100,7 +100,7 @@ class FilterScript {
         if (Util.fixEmptyAndTrim(expression)==null)
             return defaultScript;
 
-        GroovyShell shell = new GroovyShell();
+        GroovyShell shell = new GroovyShell(FilterScript.class.getClassLoader());
 
         return new FilterScript(shell.parse("use("+BooleanCategory.class.getName().replace('$','.')+") {"+expression+"}"));
     }


### PR DESCRIPTION
Since the Matrix code was moved into a plugin, any job using a combination filter fails to load at startup, and Jenkins throws an exception whilst creating new jobs with combination filters. This seems to be because the classloader used by Groovy is unaware of the `BooleanCategory` it is instructed to resolve.

This change passes the classloader used by the Matrix Plugin plugin into Groovy to overcome this loading issue.
