### PR TITLE
[FIXED JENKINS-22798] Fix method visiblilty issue

### DIFF
--- a/src/main/java/hudson/tasks/test/MatrixTestResult.java
+++ b/src/main/java/hudson/tasks/test/MatrixTestResult.java
@@ -66,4 +66,12 @@ public class MatrixTestResult extends AggregatedTestResultAction {
         // Prepend Configuration path
         return it.getOwner().getParent().getShortUrl() + super.getTestResultPath(it);
     }
+
+    /* We are required to override and call super since the parent class is in
+     * a different classloader, otherwise we get IllegalAccessErrors (JENKINS-22798)
+     */
+    @Override
+    protected void add(AbstractTestResultAction child) {
+        super.add(child);
+    }
 }


### PR DESCRIPTION
This is another issue caused by the matrix code moving into a plugin: a separate classloader is used for the plugin code that was used for the Jenkins core, so protected methods are no longer properly visible between the matrix code and the core, even when called from the same package. This commit adds a method that's visible in the plugin classloader and delegates to the class in the core classloader.
