### PR TITLE
Fix NullPointerException if swapping between MatrixExecutionStrategies

### DIFF
--- a/src/main/resources/hudson/matrix/DefaultMatrixExecutionStrategyImpl/config.groovy
+++ b/src/main/resources/hudson/matrix/DefaultMatrixExecutionStrategyImpl/config.groovy
@@ -21,8 +21,8 @@ f.optionalBlock (field:"hasTouchStoneCombinationFilter", title:_("Execute touchs
 
     f.entry(title:_("Required result"), field:"touchStoneResultCondition", description:_("required.result.description")) {
         select(name:"touchStoneResultCondition") {
-            f.option(value:"SUCCESS",  selected:my.touchStoneResultCondition==Result.SUCCESS,  _("Stable"))
-            f.option(value:"UNSTABLE", selected:my.touchStoneResultCondition==Result.UNSTABLE, _("Unstable"))
+            f.option(value:"SUCCESS",  selected:my?.touchStoneResultCondition==Result.SUCCESS,  _("Stable"))
+            f.option(value:"UNSTABLE", selected:my?.touchStoneResultCondition==Result.UNSTABLE, _("Unstable"))
         }
     }
 }


### PR DESCRIPTION
I put together an execution strategy which uses a groovy script or groovy file but swapping between the default and mine caused a NPE due to the instance field not being populated after the switch, this fixes it by checking if the instance is there before using the attributes.
