### PR TITLE
[JENKINS-25604] MatrixConfiguration.useShortWorkspaceName does not alter the workspace path

### DIFF
--- a/src/test/groovy/hudson/matrix/MatrixProjectTest.groovy
+++ b/src/test/groovy/hudson/matrix/MatrixProjectTest.groovy
@@ -67,6 +67,9 @@ import java.util.concurrent.CountDownLatch
 
 import static hudson.model.Node.Mode.EXCLUSIVE
 import static org.junit.Assert.*
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+
 import org.junit.Rule
 import org.junit.Test
 import org.jvnet.hudson.test.JenkinsRule
@@ -518,5 +521,30 @@ public class MatrixProjectTest {
             def b = j.assertBuildStatusSuccess(p.scheduleBuild2(2))
             assertSame(b.builtOn, j.jenkins)
         }
+    }
+
+    @Test
+    public void useCombinationInWorkspaceName() throws Exception {
+        MatrixProject p = j.jenkins.createProject(MatrixProject.class, "defaultName");
+        p.setAxes(new AxisList(new TextAxis("AXIS", "VALUE")));
+
+        p.scheduleBuild2(0).get();
+        def build = p.getItem("AXIS=VALUE").getLastBuild();
+
+        assertThat(build.getLogFile().getAbsolutePath(), containsString("/configurations/axis-AXIS/VALUE/builds/"));
+    }
+
+    @Test
+    public void useShortWorkspaceNameGlobally() throws Exception {
+        MatrixConfiguration.useShortWorkspaceName = true;
+
+        MatrixProject p = j.jenkins.createProject(MatrixProject.class, "shortName");
+        p.setAxes(new AxisList(new TextAxis("AXIS", "VALUE")));
+
+        p.scheduleBuild2(0).get();
+        MatrixRun build = p.getItem("AXIS=VALUE").getLastBuild();
+
+        assertThat(build.getLogFile().getAbsolutePath(), not(containsString("/configurations/axis-AXIS/VALUE/builds/")));
+        assertThat(build.getLogFile().getAbsolutePath(), containsString("/configurations/${build.parent.digestName}/builds/"));
     }
 }


### PR DESCRIPTION
[JENKINS-25604](https://issues.jenkins-ci.org/browse/JENKINS-25604) MatrixConfiguration.useShortWorkspaceName does not alter the workspace path
