### PR TITLE
[FIXED JENKINS-9277 JENKINS-25448 JENKINS-23614] Disallow special chars in axis names and values

### DIFF
--- a/src/main/java/hudson/matrix/AxisDescriptor.java
+++ b/src/main/java/hudson/matrix/AxisDescriptor.java
@@ -26,8 +26,10 @@ package hudson.matrix;
 import hudson.Util;
 import hudson.model.Descriptor;
 import hudson.model.Failure;
+import hudson.model.Messages;
 import jenkins.model.Jenkins;
 import hudson.util.FormValidation;
+
 import org.kohsuke.stapler.QueryParameter;
 
 /**
@@ -52,10 +54,47 @@ public abstract class AxisDescriptor extends Descriptor<Axis> {
 
     /**
      * Makes sure that the given name is good as a axis name.
+     *
+     * Aside from {@link Jenkins#checkGoodName()} this disallows ',' and
+     * '=' as special characters used in Combination presentation.
      */
     public FormValidation doCheckName(@QueryParameter String value) {
         if(Util.fixEmpty(value)==null)
             return FormValidation.ok();
+
+        if (value.contains(",")) return FormValidation.error(
+                Messages.Hudson_UnsafeChar(',')
+        );
+
+        if (value.contains("=")) return FormValidation.error(
+                Messages.Hudson_UnsafeChar('=')
+        );
+
+        try {
+            Jenkins.checkGoodName(value);
+            return FormValidation.ok();
+        } catch (Failure e) {
+            return FormValidation.error(e.getMessage());
+        }
+    }
+
+    /**
+     * Makes sure that the given name is good as a axis name.
+     *
+     * Aside from {@link Jenkins#checkGoodName()} this disallows ',' as
+     * special character used in Combination presentation. Note it is not
+     * necessary to disallow '=' in value as everything after the first
+     * occurrence is considered to be a value.
+     *
+     * Subclasses are expected to expose own <tt>doCheck</tt> method possibly delegating to this one.
+     */
+    public FormValidation checkValue(@QueryParameter String value) {
+        if(Util.fixEmpty(value)==null)
+            return FormValidation.ok();
+
+        if (value.contains(",")) return FormValidation.error(
+                Messages.Hudson_UnsafeChar(',')
+        );
 
         try {
             Jenkins.checkGoodName(value);

--- a/src/main/java/hudson/matrix/AxisDescriptor.java
+++ b/src/main/java/hudson/matrix/AxisDescriptor.java
@@ -26,7 +26,6 @@ package hudson.matrix;
 import hudson.Util;
 import hudson.model.Descriptor;
 import hudson.model.Failure;
-import hudson.model.Messages;
 import jenkins.model.Jenkins;
 import hudson.util.FormValidation;
 
@@ -60,15 +59,10 @@ public abstract class AxisDescriptor extends Descriptor<Axis> {
      */
     public FormValidation doCheckName(@QueryParameter String value) {
         if(Util.fixEmpty(value)==null)
-            return FormValidation.ok();
+            return FormValidation.error(Messages.AxisDescriptor_EmptyAxisName());
 
-        if (value.contains(",")) return FormValidation.error(
-                Messages.Hudson_UnsafeChar(',')
-        );
-
-        if (value.contains("=")) return FormValidation.error(
-                Messages.Hudson_UnsafeChar('=')
-        );
+        if (value.contains(",")) return unsafeChar(',');
+        if (value.contains("=")) return unsafeChar('=');
 
         try {
             Jenkins.checkGoodName(value);
@@ -90,11 +84,9 @@ public abstract class AxisDescriptor extends Descriptor<Axis> {
      */
     public FormValidation checkValue(@QueryParameter String value) {
         if(Util.fixEmpty(value)==null)
-            return FormValidation.ok();
+            return FormValidation.error(Messages.AxisDescriptor_EmptyAxisName());
 
-        if (value.contains(",")) return FormValidation.error(
-                Messages.Hudson_UnsafeChar(',')
-        );
+        if (value.contains(",")) return unsafeChar(',');
 
         try {
             Jenkins.checkGoodName(value);
@@ -102,5 +94,9 @@ public abstract class AxisDescriptor extends Descriptor<Axis> {
         } catch (Failure e) {
             return FormValidation.error(e.getMessage());
         }
+    }
+
+    private FormValidation unsafeChar(char chr) {
+        return FormValidation.error(hudson.model.Messages.Hudson_UnsafeChar(chr));
     }
 }

--- a/src/main/java/hudson/matrix/JDKAxis.java
+++ b/src/main/java/hudson/matrix/JDKAxis.java
@@ -25,9 +25,11 @@ package hudson.matrix;
 
 import hudson.Extension;
 import jenkins.model.Jenkins;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -46,7 +48,7 @@ public class JDKAxis extends Axis {
 
     @DataBoundConstructor
     public JDKAxis(String[] values) {
-        super("jdk", Arrays.asList(values));
+        super("jdk", values == null ? Collections.<String>emptyList() : Arrays.asList(values));
     }
 
     @Override

--- a/src/main/java/hudson/matrix/LabelExpAxis.java
+++ b/src/main/java/hudson/matrix/LabelExpAxis.java
@@ -90,6 +90,7 @@ public class LabelExpAxis extends Axis {
 		for(String expr: exprs){
     		expressions.add(Util.fixEmptyAndTrim(expr));
     	}
+		expressions.remove(null); // Empty / whitespace-only lines
 		return expressions;
 	}
 

--- a/src/main/java/hudson/matrix/TextAxis.java
+++ b/src/main/java/hudson/matrix/TextAxis.java
@@ -1,7 +1,12 @@
 package hudson.matrix;
 
 import hudson.Extension;
+import hudson.util.FormValidation;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
 
 import java.util.List;
 
@@ -29,6 +34,12 @@ public class TextAxis extends Axis {
         @Override
         public String getDisplayName() {
             return Messages.TextArea_DisplayName();
+        }
+
+        @Restricted(NoExternalUse.class)
+        // TODO: expandableTextbox does not support form validation
+        public FormValidation doCheckValueString(@QueryParameter String value) {
+            return super.checkValue(value);
         }
     }
 }

--- a/src/main/resources/hudson/matrix/Messages.properties
+++ b/src/main/resources/hudson/matrix/Messages.properties
@@ -24,6 +24,8 @@ MatrixBuild.depends_on_this={0} depends on this.
 MatrixProject.DisplayName=Multi-configuration project
 MatrixProject.Pronoun=Multi-configuration project
 MatrixProject.DuplicateAxisName=Duplicate axis name
+MatrixProject.InvalidAxisName=Matrix axis name ''{0}'' is invalid: {1}
+MatrixProject.InvalidAxisValue=Matrix axis value ''{0}'' is invalid: {1}
 
 MatrixBuild.Triggering=Triggering {0}
 MatrixBuild.AppearsCancelled={0} appears to be cancelled

--- a/src/main/resources/hudson/matrix/Messages.properties
+++ b/src/main/resources/hudson/matrix/Messages.properties
@@ -42,3 +42,4 @@ JDKAxis.DisplayName=JDK
 LabelAxis.DisplayName=Slaves
 LabelExpAxis.DisplayName=Label expression
 TextArea.DisplayName=User-defined Axis
+AxisDescriptor.EmptyAxisName=Axis name can not be empty

--- a/src/test/java/hudson/matrix/AxisDescriptorTest.java
+++ b/src/test/java/hudson/matrix/AxisDescriptorTest.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.matrix;
+
+import static org.junit.Assert.*;
+import hudson.util.FormValidation;
+
+import org.junit.Test;
+
+public class AxisDescriptorTest {
+
+    TextAxis.DescriptorImpl descriptor = new TextAxis.DescriptorImpl();
+
+    @Test
+    public void combinationNameSpecialChars() {
+        assertEquals(
+                FormValidation.Kind.ERROR,
+                descriptor.doCheckName("a=b").kind
+        );
+
+        assertEquals(
+                FormValidation.Kind.ERROR,
+                descriptor.doCheckName("a,b").kind
+        );
+
+        assertEquals(
+                FormValidation.Kind.ERROR,
+                descriptor.doCheckName("a/b").kind
+        );
+    }
+
+    @Test
+    public void combinationValueSpecialChars() {
+        assertEquals(
+                FormValidation.Kind.OK,
+                descriptor.checkValue("a=b").kind
+        );
+
+        assertEquals(
+                FormValidation.Kind.ERROR,
+                descriptor.checkValue("a,b").kind
+        );
+
+        assertEquals(
+                FormValidation.Kind.ERROR,
+                descriptor.checkValue("a/b").kind
+        );
+    }
+}

--- a/src/test/java/hudson/matrix/AxisTest.java
+++ b/src/test/java/hudson/matrix/AxisTest.java
@@ -1,0 +1,113 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.matrix;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import hudson.model.JDK;
+
+import org.hamcrest.collection.IsEmptyCollection;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
+
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+public class AxisTest {
+
+    public @Rule JenkinsRule j = new JenkinsRule();
+
+    private MatrixProject p;
+    private WebClient wc;
+
+    @Before
+    public void setUp() throws Exception {
+        wc = j.createWebClient();
+        p = j.createMatrixProject();
+
+        // Setup to make all axes available
+        j.jenkins.getJDKs().add(new JDK("jdk1.7", "/fake/home"));
+        j.createSlave();
+    }
+
+    @Test
+    public void submitEmptyAxisName() throws Exception {
+        wc.setThrowExceptionOnFailingStatusCode(false);
+
+        final String expectedMsg = "Matrix axis name '' is invalid: Axis name can not be empty";
+        assertFailedWith(emptyName("User-defined Axis"), expectedMsg);
+        assertFailedWith(emptyName("Slaves"), expectedMsg);
+        assertFailedWith(emptyName("Label expression"), expectedMsg);
+        //assertFailedWith(emptyName("JDK"), expectedMsg); // No "name" attribute
+    }
+
+    private HtmlPage emptyName(String axis) throws Exception {
+        HtmlForm form = addAxis(axis);
+        form.getInputByName("_.name").setValueAttribute("");
+        HtmlPage ret = j.submit(form);
+        return ret;
+    }
+
+    @Test
+    public void emptyAxisValueListResultInNoConfigurations() throws Exception {
+        emptyValue("User-defined Axis");
+        emptyValue("Slaves");
+        emptyValue("Label expression");
+        emptyValue("JDK");
+
+        MatrixBuild build = j.buildAndAssertSuccess(p);
+        assertThat(build.getRuns(), new IsEmptyCollection<MatrixRun>());
+        assertThat(p.getItems(), new IsEmptyCollection<MatrixConfiguration>());
+    }
+
+    private HtmlPage emptyValue(String axis) throws Exception {
+        HtmlForm form = addAxis(axis);
+        if (!"JDK".equals(axis)) { // No "name" attribute
+            form.getInputByName("_.name").setValueAttribute("some_name");
+        }
+
+        HtmlPage ret = j.submit(form);
+        return ret;
+    }
+
+    private void assertFailedWith(HtmlPage res, String expected) {
+        String actual = res.getWebResponse().getContentAsString();
+
+        assertThat(actual, res.getWebResponse().getStatusCode(), equalTo(400));
+        assertThat(actual, containsString(expected));
+    }
+
+    private HtmlForm addAxis(String axis) throws Exception {
+        HtmlPage page = wc.getPage(p, "configure");
+        HtmlForm form = page.getFormByName("config");
+        form.getButtonByCaption("Add axis").click();
+        page.getAnchorByText(axis).click();
+        return form;
+    }
+}


### PR DESCRIPTION
Fixes [JENKINS-9277](https://issues.jenkins-ci.org/browse/JENKINS-9277), [JENKINS-25448](https://issues.jenkins-ci.org/browse/JENKINS-25448), [JENKINS-23614](https://issues.jenkins-ci.org/browse/JENKINS-23614).

From now on:
- Axis needs to provide non-empty name otherwise form submission is rejected.
- Axis name can not contain `=`and `,`, values can not contain `,` as those have special meaning. Form submission is rejected in such a case.
- Empty list of axis values are allowed, though I am not aware of any use case for that.