### PR TITLE
Display axis name

### DIFF
--- a/src/main/resources/lib/hudson/matrix-project/matrix.jelly
+++ b/src/main/resources/lib/hudson/matrix-project/matrix.jelly
@@ -63,7 +63,9 @@ THE SOFTWARE.
               </j:if>
               <j:forEach begin="1" end="${o.repeatX(loop.index)}">
                 <j:forEach var="v" items="${x.values}">
-                  <td class="matrix-header" colspan="${o.width(loop.index)}">${v}</td>
+                  <td class="matrix-header" colspan="${o.width(loop.index)}">
+                    <div tooltip="${x.name}">${v}</div>
+                  </td>
                 </j:forEach>
               </j:forEach>
             </tr>
@@ -74,7 +76,9 @@ THE SOFTWARE.
             <tr>
               <j:forEach var="y" items="${o.y}" varStatus="loop">
                 <j:if test="${r.drawYHeader(loop.index)!=null}">
-                  <td class="matrix-leftcolumn" rowspan="${o.height(loop.index)}">${r.drawYHeader(loop.index)}</td>
+                  <td class="matrix-leftcolumn" rowspan="${o.height(loop.index)}">
+                    <div tooltip="${y.name}">${r.drawYHeader(loop.index)}</div>
+                  </td>
                 </j:if>
               </j:forEach>
 


### PR DESCRIPTION
Display axis name in matrix table.

# Why?
If exists same values in different axises, matrix table is difficult to read.

# Example
## Configure
![1_configure](https://cloud.githubusercontent.com/assets/608755/5792863/b100a630-9f6f-11e4-933b-4dba2c9183b5.png)

## Before
![2_before](https://cloud.githubusercontent.com/assets/608755/5792864/b31a6ed8-9f6f-11e4-9b7a-48fa50a47930.png)

I think this is hard to understand the results of the test

## After
![3_after](https://cloud.githubusercontent.com/assets/608755/5792865/b45bc6f2-9f6f-11e4-804d-a0731eb70f54.png)