### PR TITLE
[JENKINS-27066] Runs all aggregators even any of them throws exception.

### DIFF
--- a/src/main/java/hudson/matrix/MatrixAggregator.java
+++ b/src/main/java/hudson/matrix/MatrixAggregator.java
@@ -97,7 +97,8 @@ public abstract class MatrixAggregator implements ExtensionPoint {
      * to indicate that the build is about to finish.
      * 
      * @return
-     *      See {@link #startBuild()} for the return value semantics.
+     *      true if the aggregation succeeded, false if there was an error.
+     *      The build will continue even if you return false.
      */
     public boolean endBuild() throws InterruptedException, IOException {
         return true;

--- a/src/main/java/hudson/matrix/MatrixBuild.java
+++ b/src/main/java/hudson/matrix/MatrixBuild.java
@@ -402,10 +402,10 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
                 // all aggregations will be performed even any of them failed.
                 try {
                     if (!a.endBuild()) {
-                        listener.error("Aggregation failed for {0}", a.toString());
+                        listener.error(String.format("Aggregation failed for %s", a.toString()));
                     }
                 } catch (Exception e) {
-                    e.printStackTrace(listener.error("Aggregation failed for {0}", a.toString()));
+                    e.printStackTrace(listener.error(String.format("Aggregation failed for %s", a.toString())));
                     setResult(Result.FAILURE);
                 }
         }

--- a/src/main/java/hudson/matrix/MatrixBuild.java
+++ b/src/main/java/hudson/matrix/MatrixBuild.java
@@ -399,7 +399,15 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
 
         public void post2(BuildListener listener) throws Exception {
             for (MatrixAggregator a : aggregators)
-                a.endBuild();
+                // all aggregations will be performed even any of them failed.
+                try {
+                    if (!a.endBuild()) {
+                        listener.error("Aggregation failed for {0}", a.toString());
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace(listener.error("Aggregation failed for {0}", a.toString()));
+                    setResult(Result.FAILURE);
+                }
         }
     }
 }

--- a/src/test/java/hudson/matrix/MatrixAggregationTest.java
+++ b/src/test/java/hudson/matrix/MatrixAggregationTest.java
@@ -1,0 +1,280 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2015 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.matrix;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import hudson.Launcher;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Publisher;
+import hudson.tasks.Recorder;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+import com.google.common.collect.Sets;
+
+/**
+ *
+ */
+public class MatrixAggregationTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    
+    /**
+     * recorder records what operations are called for what builds.
+     */
+    public static class AggregationRecorder extends Recorder implements MatrixAggregatable {
+        public List<AbstractBuild<?,?>> buildsPerformed = new CopyOnWriteArrayList<AbstractBuild<?,?>>();
+        public List<MatrixBuild> buildsStarted = new CopyOnWriteArrayList<MatrixBuild>();
+        public List<MatrixRun> runsEnded = new CopyOnWriteArrayList<MatrixRun>();
+        public List<MatrixBuild> buildsEnded = new CopyOnWriteArrayList<MatrixBuild>();
+        
+        @Override
+        public BuildStepMonitor getRequiredMonitorService() {
+            return BuildStepMonitor.NONE;
+        }
+        
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+                BuildListener listener) throws InterruptedException, IOException {
+            buildsPerformed.add(build);
+            return true;
+        }
+        
+        @Override
+        public MatrixAggregator createAggregator(MatrixBuild build,
+                Launcher launcher, BuildListener listener) {
+            return new MatrixAggregator(build, launcher, listener) {
+                @Override
+                public boolean startBuild() throws InterruptedException, IOException {
+                    buildsStarted.add(build);
+                    return true;
+                }
+                
+                @Override
+                public boolean endRun(MatrixRun run) throws InterruptedException, IOException {
+                    runsEnded.add(run);
+                    return true;
+                }
+                
+                @Override
+                public boolean endBuild() throws InterruptedException, IOException {
+                    buildsEnded.add(build);
+                    return true;
+                }
+            };
+        }
+        
+        @TestExtension
+        public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+            @Override
+            public boolean isApplicable(Class<? extends AbstractProject> arg0) {
+                return true;
+            }
+            
+            @Override
+            public String getDisplayName() {
+                return "AggregationRecorder";
+            }
+        }
+    }
+    
+    /**
+     * recorder whose aggregation fails in endBuild.
+     */
+    public static class EndBuildFailRecorder extends Recorder implements MatrixAggregatable {
+        @Override
+        public BuildStepMonitor getRequiredMonitorService() {
+            return BuildStepMonitor.NONE;
+        }
+        
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+                BuildListener listener) throws InterruptedException, IOException {
+            return true;
+        }
+        
+        @Override
+        public MatrixAggregator createAggregator(MatrixBuild build,
+                Launcher launcher, BuildListener listener) {
+            return new MatrixAggregator(build, launcher, listener) {
+                @Override
+                public boolean endBuild() throws InterruptedException, IOException {
+                    return false;
+                }
+            };
+        }
+        
+        @TestExtension
+        public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+            @Override
+            public boolean isApplicable(Class<? extends AbstractProject> arg0) {
+                return true;
+            }
+            
+            @Override
+            public String getDisplayName() {
+                return "EndBuildFailRecorder";
+            }
+        }
+    }
+    
+    /**
+     * recorder whose aggregation raises an exception in endBuild.
+     */
+    public static class EndBuildRaiseExceptionRecorder extends Recorder implements MatrixAggregatable {
+        @Override
+        public BuildStepMonitor getRequiredMonitorService() {
+            return BuildStepMonitor.NONE;
+        }
+        
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+                BuildListener listener) throws InterruptedException, IOException {
+            return true;
+        }
+        
+        @Override
+        public MatrixAggregator createAggregator(MatrixBuild build,
+                Launcher launcher, BuildListener listener) {
+            return new MatrixAggregator(build, launcher, listener) {
+                @Override
+                public boolean endBuild() throws InterruptedException, IOException {
+                    throw new IOException("Exception to test the behavior");
+                }
+            };
+        }
+        
+        @TestExtension
+        public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+            @Override
+            public boolean isApplicable(Class<? extends AbstractProject> arg0) {
+                return true;
+            }
+            
+            @Override
+            public String getDisplayName() {
+                return "EndBuildRaiseExceptionRecorder";
+            }
+        }
+    }
+    
+    @Test
+    public void testAggregation() throws Exception {
+        MatrixProject p = j.createMatrixProject();
+        AxisList axisList = new AxisList(new TextAxis("axis1", "value1", "value2"));
+        p.setAxes(axisList);
+        
+        AggregationRecorder rec = new AggregationRecorder();
+        p.getPublishersList().add(rec);
+        
+        MatrixBuild b = p.scheduleBuild2(0).get();
+        j.assertBuildStatusSuccess(b);
+        
+        // perform is called for all child builds.
+        assertEquals(
+                Sets.newHashSet(
+                        b.getExactRun(new Combination(axisList, "value1")),
+                        b.getExactRun(new Combination(axisList, "value2"))
+                ),
+                Sets.newHashSet(rec.buildsPerformed)
+        );
+        // startBuild is called for the parent.
+        assertEquals(
+                Arrays.asList(b),
+                rec.buildsStarted
+        );
+        // endRun is called for all child builds.
+        assertEquals(
+                Sets.newHashSet(
+                        b.getExactRun(new Combination(axisList, "value1")),
+                        b.getExactRun(new Combination(axisList, "value2"))
+                ),
+                Sets.newHashSet(rec.runsEnded)
+        );
+        // endBuild is called for the parent.
+        assertEquals(
+                Arrays.asList(b),
+                rec.buildsEnded
+        );
+    }
+    
+    @Test
+    public void testEndBuildFails() throws Exception {
+        MatrixProject p = j.createMatrixProject();
+        AxisList axisList = new AxisList(new TextAxis("axis1", "value1", "value2"));
+        p.setAxes(axisList);
+        
+        p.getPublishersList().add(new EndBuildFailRecorder());
+        AggregationRecorder rec = new AggregationRecorder();
+        p.getPublishersList().add(rec);
+        
+        MatrixBuild b = p.scheduleBuild2(0).get();
+        
+        // failure in aggregation doesn't affect build results.
+        // It's expected to be set in aggregatiors if needed.
+        j.assertBuildStatusSuccess(b);
+        
+        // endBuild is called for the parent even after an aggregator fails.
+        assertEquals(
+                Arrays.asList(b),
+                rec.buildsEnded
+        );
+    }
+    
+    @Test
+    public void testEndBuildThrowsException() throws Exception {
+        MatrixProject p = j.createMatrixProject();
+        AxisList axisList = new AxisList(new TextAxis("axis1", "value1", "value2"));
+        p.setAxes(axisList);
+        
+        p.getPublishersList().add(new EndBuildRaiseExceptionRecorder());
+        AggregationRecorder rec = new AggregationRecorder();
+        p.getPublishersList().add(rec);
+        
+        MatrixBuild b = p.scheduleBuild2(0).get();
+        
+        j.assertBuildStatus(Result.FAILURE, b);
+        
+        // endBuild is called for the parent even after an aggregator fails.
+        assertEquals(
+                Arrays.asList(b),
+                rec.buildsEnded
+        );
+    }
+}


### PR DESCRIPTION
[JENKINS-27066](https://issues.jenkins-ci.org/browse/JENKINS-27066)

Please consider a project with following publishers executed in this order:
- A publisher with a bug throwing an exception in its aggregation. (publisher A)
- A publisher sends notification with its aggregation. (publisher B)

Matrix-project 1.4 doesn't perform the aggregation of publisher B.

Of course, I agree that I should fix the problem in publisher A.
At the same time, I don't think it's useful that a bug in a publisher disables following aggregations. It may prevent notifications from sent to users.

I want matrix-project perform all aggregations even when any of them fail.
