### PR TITLE
Show axis in table format even if there's only one value in the axis

### DIFF
--- a/src/main/java/hudson/matrix/Layouter.java
+++ b/src/main/java/hudson/matrix/Layouter.java
@@ -74,7 +74,7 @@ public abstract class Layouter<T> {
 
         List<Axis> nonTrivialAxes = new ArrayList<Axis>();
         for (Axis a : axisList) {
-            if(a.size()>1)
+            if(a.size()>=1)
                 nonTrivialAxes.add(a);
             else
                 trivial.add(a);


### PR DESCRIPTION
I find showing the current view of showing the axis when there's only 1 value is a bit messy and I very much prefer to show them inside a table cell regardless of the number of values in the axis. 