### PR TITLE
Persist the parent in ParentBuildAction

### DIFF
--- a/src/main/java/hudson/matrix/MatrixBuild.java
+++ b/src/main/java/hudson/matrix/MatrixBuild.java
@@ -385,7 +385,7 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
                         for (MatrixConfiguration c : activeConfigurations) {
                             for (Item i : q.getItems(c)) {
                                 ParentBuildAction a = i.getAction(ParentBuildAction.class);
-                                if (a!=null && a.parent==getBuild()) {
+                                if (a!=null && a.getMatrixBuild()==getBuild()) {
                                     q.cancel(i);
                                     logger.println(Messages.MatrixBuild_Cancelled(ModelHyperlinkNote.encodeTo(c)));
                                 }

--- a/src/main/java/hudson/matrix/MatrixConfiguration.java
+++ b/src/main/java/hudson/matrix/MatrixConfiguration.java
@@ -34,7 +34,6 @@ import hudson.model.Queue.QueueAction;
 import hudson.model.TaskListener;
 import hudson.util.AlternativeUiTextProvider;
 import hudson.util.DescribableList;
-import hudson.model.AbstractBuild;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.DependencyGraph;
@@ -50,6 +49,7 @@ import hudson.model.Project;
 import hudson.model.SCMedItem;
 import hudson.model.Queue.NonBlockingTask;
 import hudson.model.Cause.LegacyCodeCause;
+import hudson.model.Run;
 import hudson.scm.SCM;
 import jenkins.scm.SCMCheckoutStrategy;
 import hudson.tasks.BuildWrapper;
@@ -285,12 +285,11 @@ public class MatrixConfiguration extends Project<MatrixConfiguration,MatrixRun> 
             LOGGER.log(Level.WARNING, "JENKINS-26582: ignoring apparent attempt to trigger {0} without its parent", getFullName());
             return null;
         }
-        MatrixBuild lb = a.parent;
+        MatrixBuild lb = a.getMatrixBuild();
         if (lb == null) {
             // Could happen if the parent started but Jenkins was restarted while the children were still in the queue.
             // In this case we simply guess that the last build of the parent is what triggered this configuration.
             // If MatrixProject.concurrentBuild, that is not necessarily correct.
-            // TODO would be better to have ParentBuildAction record a nontransient MatrixBuild.id so we could reliably recover it.
             lb = getParent().getLastBuild();
             if (lb == null) {
                 LOGGER.log(Level.WARNING, "cannot start a build of {0} since its parent has no builds at all", getFullName());
@@ -492,16 +491,33 @@ public class MatrixConfiguration extends Project<MatrixConfiguration,MatrixRun> 
      */
     public static class ParentBuildAction extends InvisibleAction implements QueueAction {
         
+        /**
+         * @deprecated use {@link #getMatrixBuild()} instead.  
+         */
+        @Deprecated
         public transient MatrixBuild parent;
+        private String parentId;
 
         public ParentBuildAction() {
             final Executor currentExecutor = Executor.currentExecutor();
             this.parent = currentExecutor != null 
                     ? (MatrixBuild)currentExecutor.getCurrentExecutable() : null;
+            parentId = parent != null ? parent.getExternalizableId() : null;
         }
         
         public boolean shouldSchedule(List<Action> actions) {
             return true;
+        }
+        
+        public MatrixBuild getMatrixBuild() {
+            if (parent == null && parentId != null) {
+                try {
+                    parent = (MatrixBuild)Run.fromExternalizableId(parentId);
+                } catch (Exception e) {
+                    parent = null;
+                }
+            }
+            return parent;
         }
     }
 

--- a/src/test/java/hudson/matrix/RestartingRestoreTest.java
+++ b/src/test/java/hudson/matrix/RestartingRestoreTest.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 EvilTK.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.matrix;
+
+import com.google.inject.Inject;
+import hudson.matrix.MatrixConfiguration.ParentBuildAction;
+import jenkins.model.Jenkins;
+import static org.junit.Assert.*;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+/**
+ *
+ */
+public class RestartingRestoreTest {
+
+    @Rule public RestartableJenkinsRule r = new RestartableJenkinsRule();
+    @Inject private Jenkins jenkins;
+
+    private String matrixBuildId;
+    
+    /**
+     * Makes sure that the parent of a MatrixRun survives a restart.
+     */
+    @Test public void persistenceOfParentInMatrixRun() {     
+        r.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                MatrixProject p = r.j.createMatrixProject("project");
+                p.setAxes(new AxisList(new TextAxis("AXIS", "VALUE")));
+
+                // Schedule and wait for build to finish
+                p.scheduleBuild2(0).get();
+
+                MatrixRun run = p.getItem("AXIS=VALUE").getLastBuild();
+                ParentBuildAction a = run.getAction(ParentBuildAction.class);
+                matrixBuildId = a.getMatrixBuild().getExternalizableId();
+            }
+        });
+        r.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                MatrixProject p = jenkins.getItemByFullName("project", MatrixProject.class);
+
+                MatrixRun run = p.getItem("AXIS=VALUE").getLastBuild();
+                ParentBuildAction a = run.getAction(ParentBuildAction.class);
+                String restoredBuildId = a.getMatrixBuild().getExternalizableId();
+                
+                assertEquals(matrixBuildId, restoredBuildId);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Allows to retrieve the parent build in case Jenkins has restarted.
