### PR TITLE
[JENKINS-33230] Disable WARNING log when folder is already existed

### DIFF
--- a/src/main/java/hudson/matrix/MatrixProject.java
+++ b/src/main/java/hudson/matrix/MatrixProject.java
@@ -767,7 +767,7 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
         File f = getConfigurationsDir();
         for (Entry<String, String> e : combination.entrySet())
             f = new File(f,"axis-"+e.getKey()+'/'+Util.rawEncode(e.getValue()));
-        if (!f.getParentFile().mkdirs()) {
+        if (!f.getParentFile().exists() && !f.getParentFile().mkdirs()) {
             LOGGER.log(Level.WARNING, "Cannot create directory {0} for the combination {1}", new Object[]{f, combination});
         }
         return f;


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-33230