### PR TITLE
Fix test that failed randomly (?)

### DIFF
--- a/src/test/java/hudson/matrix/MatrixProjectTest.java
+++ b/src/test/java/hudson/matrix/MatrixProjectTest.java
@@ -93,7 +93,6 @@ import java.util.Set;
 import jenkins.model.Jenkins;
 import static org.junit.Assert.*;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;

--- a/src/test/java/hudson/matrix/MatrixProjectTest.java
+++ b/src/test/java/hudson/matrix/MatrixProjectTest.java
@@ -93,6 +93,7 @@ import java.util.Set;
 import jenkins.model.Jenkins;
 import static org.junit.Assert.*;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -134,7 +135,6 @@ public class MatrixProjectTest {
     /**
      * Tests that axes are available as build variables in the Maven builds.
      */
-    @RandomlyFails("Not a v4.0.0 POM. for project org.jvnet.maven-antrun-extended-plugin:maven-antrun-extended-plugin at /home/jenkins/.m2/repository/org/jvnet/maven-antrun-extended-plugin/maven-antrun-extended-plugin/1.40/maven-antrun-extended-plugin-1.40.pom")
     @Test
     public void testBuildAxisInMaven() throws Exception {
         MatrixProject p = createMatrixProject();

--- a/src/test/resources/hudson/matrix/echo-property.pom
+++ b/src/test/resources/hudson/matrix/echo-property.pom
@@ -36,7 +36,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.jvnet.maven-antrun-extended-plugin</groupId>
         <artifactId>maven-antrun-extended-plugin</artifactId>
-        <version>1.40</version>
+        <version>1.42</version>
         <executions>
           <execution>
             <phase>validate</phase>


### PR DESCRIPTION
The `@RandomlyFails` has been there for ages, but it's failing consistently in my machine. It seems to be an issue with `maven-antrun-extended-plugin:1.40` pom, upgrading to 1.42 in the test pom makes the test pass always (at least in my last 10 runs).

@reviewbybees 