### PR TITLE
[JENKINS-26281] Matrix builds can be deleted

### DIFF
--- a/src/main/java/hudson/matrix/MatrixBuild.java
+++ b/src/main/java/hudson/matrix/MatrixBuild.java
@@ -41,6 +41,8 @@ import hudson.tasks.junit.JUnitResultArchiver;
 import hudson.tasks.test.TestResultAggregator;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -252,12 +254,19 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
         return r;
     }
 
-    @Override
-    public String getWhyKeepLog() {
+    /**
+     * Simple extension to {@link #getWhyKeepLog()} required in order to have a warning
+     * which does not prevent the actual deletion.
+     * @return message displayed deleting build
+     */
+    @Restricted(NoExternalUse.class)
+    public String getDeleteMessage() {
         MatrixBuild b = getNextBuild();
-        if (isLinkedBy(b))
-            return Messages.MatrixBuild_depends_on_this(b.getDisplayName());
-        return super.getWhyKeepLog();
+        String message = getWhyKeepLog();
+        if (isLinkedBy(b)) {
+            message = Messages.MatrixBuild_depends_on_this(b.getDisplayName());
+        }
+        return message;
     }
 
     /** 

--- a/src/main/java/hudson/matrix/MatrixRun.java
+++ b/src/main/java/hudson/matrix/MatrixRun.java
@@ -30,6 +30,8 @@ import hudson.model.Build;
 import hudson.model.Node;
 import hudson.slaves.WorkspaceList;
 import hudson.slaves.WorkspaceList.Lease;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
@@ -126,14 +128,19 @@ public class MatrixRun extends Build<MatrixConfiguration,MatrixRun> {
     }
 
     /**
-     * If the parent {@link MatrixBuild} is kept, keep this record too.
-     */
-    @Override
-    public String getWhyKeepLog() {
+     * Simple extension to {@link #getWhyKeepLog()} required in order to have a warning
+     * which does not prevent the actual deletion.
+     * If parent build displays warning on delete, display it for run too.
+     * @return message displayed deleting run
+     **/
+    @Restricted(NoExternalUse.class)
+    public String getDeleteMessage() {
         MatrixBuild pb = getParentBuild();
-        if(pb!=null && pb.getWhyKeepLog()!=null)
-            return Messages.MatrixRun_KeptBecauseOfParent(pb);
-        return super.getWhyKeepLog();
+        String message = getWhyKeepLog();
+        if(pb != null) {
+            message = pb.getDeleteMessage();
+        }
+        return message;
     }
 
     @Override

--- a/src/main/resources/hudson/matrix/Messages.properties
+++ b/src/main/resources/hudson/matrix/Messages.properties
@@ -37,8 +37,6 @@ MatrixBuild.Completed={0} completed with result {1}
 MatrixConfiguration.Pronoun=Configuration
 MatrixConfiguration.DisableNotAllowed=Matrix configurations cannot be disabled separately. Disable the parent project instead
 
-MatrixRun.KeptBecauseOfParent=Kept because {0} is kept
-
 JDKAxis.DisplayName=JDK
 LabelAxis.DisplayName=Slaves
 LabelExpAxis.DisplayName=Label expression

--- a/src/main/resources/hudson/matrix/Messages_da.properties
+++ b/src/main/resources/hudson/matrix/Messages_da.properties
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-MatrixRun.KeptBecauseOfParent=Gemt da {0} er gemt
 TextArea.DisplayName=Brugerdefineret akse
 MatrixProject.DuplicateAxisName=Dupliker akse navn
 MatrixBuild.Triggering=Starter {0}

--- a/src/main/resources/hudson/matrix/Messages_de.properties
+++ b/src/main/resources/hudson/matrix/Messages_de.properties
@@ -36,8 +36,6 @@ MatrixBuild.Completed={0} beendet mit Ergebnis {1}
 
 MatrixConfiguration.Pronoun=Konfiguration
 
-MatrixRun.KeptBecauseOfParent=Zur\u00FCckbehalten, weil {0} zur\u00FCckbehalten wurde.
-
 
 
 LabelExpAxis.DisplayName=Labelausdruck

--- a/src/main/resources/hudson/matrix/Messages_es.properties
+++ b/src/main/resources/hudson/matrix/Messages_es.properties
@@ -32,7 +32,6 @@ MatrixBuild.Interrupting=Abortando {0}
 
 MatrixConfiguration.Pronoun=Configuraci\u00F3n
 
-MatrixRun.KeptBecauseOfParent=Guardado porque {0} est\u00E1 guardado
 TextArea.DisplayName=Ejes definidos por el usuario
 LabelAxis.DisplayName=Esclavos
 JDKAxis.DisplayName= Jdk

--- a/src/main/resources/hudson/matrix/Messages_ja.properties
+++ b/src/main/resources/hudson/matrix/Messages_ja.properties
@@ -33,8 +33,6 @@ MatrixBuild.Interrupting={0}\u3078\u306E\u5272\u308A\u8FBC\u307F
 MatrixBuild.Completed={0} \u304C\u5B8C\u4E86\u3057\u307E\u3057\u305F\u3002\u7D50\u679C: {1}
 
 MatrixConfiguration.Pronoun=\u8A2D\u5B9A
-MatrixRun.KeptBecauseOfParent={0}\u304C\u4FDD\u7559\u4E2D\u306E\u305F\u3081\u4FDD\u7559\u3057\u307E\u3059
-
 JDKAxis.DisplayName=JDK
 LabelAxis.DisplayName=\u30B9\u30EC\u30FC\u30D6
 LabelExpAxis.DisplayName=\u30E9\u30D9\u30EB\u5F0F

--- a/src/main/resources/hudson/matrix/Messages_nl.properties
+++ b/src/main/resources/hudson/matrix/Messages_nl.properties
@@ -29,4 +29,4 @@ MatrixBuild.Cancelled= {0} werd geannuleerd
 MatrixBuild.Interrupting= {0} wordt onderbroken
 
 MatrixConfiguration.Pronoun=Configuratie
-MatrixRun.KeptBecauseOfParent=Bijgehouden omdat {0} werd bijgehouden
+

--- a/src/main/resources/hudson/matrix/Messages_pt.properties
+++ b/src/main/resources/hudson/matrix/Messages_pt.properties
@@ -22,7 +22,6 @@
 
 
 MatrixBuild.Completed={0} completado com resultado {1}
-MatrixRun.KeptBecauseOfParent=Mantido porque {0} ser\u00e1 mantido
 TextArea.DisplayName=Eixo definido pelo usu\u00e1rio
 MatrixProject.DuplicateAxisName=Nome do eixo duplicado
 MatrixBuild.Triggering=Disparando {0}

--- a/src/main/resources/hudson/matrix/Messages_pt_BR.properties
+++ b/src/main/resources/hudson/matrix/Messages_pt_BR.properties
@@ -34,8 +34,6 @@ MatrixBuild.Interrupting=Interrompendo {0}
 MatrixBuild.Completed={0} completado com o resultado {1}
 
 MatrixConfiguration.Pronoun=Configura\u00E7\u00E3o
-MatrixRun.KeptBecauseOfParent=Mantido porque {0} est\u00E1 mantido
-
 MatrixProject.DuplicateAxisName=Duplicar nome do eixo
 
 JDKAxis.DisplayName=JDK

--- a/src/main/resources/hudson/matrix/Messages_tr.properties
+++ b/src/main/resources/hudson/matrix/Messages_tr.properties
@@ -29,4 +29,4 @@ MatrixBuild.Cancelled={0} iptal edildi
 MatrixBuild.Interrupting={0} i\u015Flemi kesiliyor
 
 MatrixConfiguration.Pronoun=Konfig\u00FCrasyon
-MatrixRun.KeptBecauseOfParent={0} tutuldu\u011Fu i\u00E7in tutulmu\u015Ftur
+

--- a/src/main/resources/hudson/matrix/Messages_zh_CN.properties
+++ b/src/main/resources/hudson/matrix/Messages_zh_CN.properties
@@ -31,8 +31,6 @@ MatrixBuild.Interrupting=Interrupting {0}
 
 MatrixConfiguration.Pronoun=Configuration
 
-MatrixRun.KeptBecauseOfParent=Kept because {0} is kept
-
 JDKAxis.DisplayName=JDK
 LabelAxis.DisplayName=Slaves
 TextArea.DisplayName=User-defined Axis

--- a/src/main/resources/hudson/matrix/Messages_zh_TW.properties
+++ b/src/main/resources/hudson/matrix/Messages_zh_TW.properties
@@ -32,8 +32,6 @@ MatrixBuild.Completed={0} \u5DF2\u5B8C\u6210\uFF0C\u7D50\u679C\u70BA {1}
 
 MatrixConfiguration.Pronoun=\u8A2D\u5B9A
 
-MatrixRun.KeptBecauseOfParent=\u70BA\u4E86 {0} \u800C\u4FDD\u7559
-
 JDKAxis.DisplayName=JDK
 LabelAxis.DisplayName=Slave
 LabelExpAxis.DisplayName=\u6A19\u7C64\u8868\u793A\u5F0F

--- a/src/main/resources/hudson/model/Run/confirmDelete.jelly
+++ b/src/main/resources/hudson/model/Run/confirmDelete.jelly
@@ -1,0 +1,53 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, id:cactusman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<!--
+ Modification of https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/model/Run/confirmDelete.jelly
+
+ We copy this template in order to use it.deleteMessage instead of it.whyKeepLog as displayed message.
+ This is required in order to have a warning which does not prevent the actual deletion.
+-->
+
+<!-- Confirm deletion of the build/run -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <l:layout title="${it.fullDisplayName}" norefresh="true">
+    <st:include page="sidepanel.jelly"/>
+    <l:main-panel>
+      <j:set var="msg" value="${it.deleteMessage}"/>
+      <j:if test="${msg!=null}">
+        <p class="warning">${%Warning}: ${msg}</p>
+      </j:if>
+
+      <j:if test="${it.whyKeepLog==null}">
+        <form method="post" action="doDelete">
+          ${%Are you sure about deleting the build?}
+          <f:submit value="${%Yes}"/>
+        </form>
+      </j:if>
+
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/src/test/java/hudson/matrix/MatrixProjectTest.java
+++ b/src/test/java/hudson/matrix/MatrixProjectTest.java
@@ -612,7 +612,7 @@ public class MatrixProjectTest {
     }
 
     @Test @Issue("JENKINS-13554")
-    public void deletedParentBuildWithLockedChildren() throws Exception {
+    public void deletedParentBuildWithLatestChildrenResult() throws Exception {
         MatrixProject p = j.jenkins.createProject(MatrixProject.class, "project");
         p.setAxes(new AxisList(new TextAxis("AXIS", "VALUE")));
         MatrixBuild build = p.scheduleBuild2(0).get();
@@ -621,7 +621,11 @@ public class MatrixProjectTest {
         MatrixConfiguration c = p.getItem("AXIS=VALUE");
 
         c.getBuildByNumber(2).delete(); // delete newest run
-        assertNotNull(c.getBuildByNumber(1).getWhyKeepLog());
+        assertNull("build #1 should not be locked", p.getBuildByNumber(1).getWhyKeepLog());
+        assertNotNull("build #1 should have delete message", p.getBuildByNumber(1).getDeleteMessage());
+
+        assertNull("configuration run #1 should not be locked", c.getBuildByNumber(1).getWhyKeepLog());
+        assertNotNull("configuration run #1 should have delete message", c.getBuildByNumber(1).getDeleteMessage());
 
         build.delete();
 


### PR DESCRIPTION
These changes allow users to delete matrix builds even if they previously were supposed to be kept. 

See JENKINS-26281 and JENKINS-13554 for more details. 
