### PR TITLE
Fix race condition

### DIFF
--- a/src/test/resources/hudson/matrix/echo-property.pom
+++ b/src/test/resources/hudson/matrix/echo-property.pom
@@ -36,7 +36,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.jvnet.maven-antrun-extended-plugin</groupId>
         <artifactId>maven-antrun-extended-plugin</artifactId>
-        <version>1.42</version>
+        <version>1.43</version>
         <executions>
           <execution>
             <phase>validate</phase>
@@ -57,7 +57,7 @@ THE SOFTWARE.
   <pluginRepositories>
     <pluginRepository>
       <id>m.g.o-public</id>
-      <url>http://maven.glassfish.org/content/groups/public/</url>
+      <url>https://maven.java.net/content/groups/public/</url>
       <releases>
         <enabled>true</enabled>
       </releases>


### PR DESCRIPTION
Before this change a build failure returning an NPE could happen when calling getCauseOfBlockage() for matrix projects sitting in the jenkins queue for more than 5 seconds. Specifically it could happen that jenkins asynchronously scheduled the build run between the original `null` checks and the call to getCauseOfBlockage().