### PR TITLE
Record parent build number reliably

### DIFF
--- a/src/main/java/hudson/matrix/MatrixBuild.java
+++ b/src/main/java/hudson/matrix/MatrixBuild.java
@@ -302,7 +302,7 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
                     throw HttpResponses.redirectViaContextPath(url);
                 }
             }
-        } catch (IllegalArgumentException _) {
+        } catch (IllegalArgumentException ex) {
             // failed to parse the token as Combination. Must be something else
         }
         return super.getDynamic(token,req,rsp);

--- a/src/main/java/hudson/matrix/MatrixBuild.java
+++ b/src/main/java/hudson/matrix/MatrixBuild.java
@@ -385,7 +385,7 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
                         for (MatrixConfiguration c : activeConfigurations) {
                             for (Item i : q.getItems(c)) {
                                 ParentBuildAction a = i.getAction(ParentBuildAction.class);
-                                if (a!=null && a.parent==getBuild()) {
+                                if (a!=null && a.resolve(getProject())==getBuild()) {
                                     q.cancel(i);
                                     logger.println(Messages.MatrixBuild_Cancelled(ModelHyperlinkNote.encodeTo(c)));
                                 }

--- a/src/main/java/hudson/matrix/MatrixBuild.java
+++ b/src/main/java/hudson/matrix/MatrixBuild.java
@@ -385,7 +385,7 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
                         for (MatrixConfiguration c : activeConfigurations) {
                             for (Item i : q.getItems(c)) {
                                 ParentBuildAction a = i.getAction(ParentBuildAction.class);
-                                if (a!=null && a.resolve(getProject())==getBuild()) {
+                                if (a!=null && a.getParentBuild(getProject())==getBuild()) {
                                     q.cancel(i);
                                     logger.println(Messages.MatrixBuild_Cancelled(ModelHyperlinkNote.encodeTo(c)));
                                 }

--- a/src/main/java/hudson/matrix/MatrixConfiguration.java
+++ b/src/main/java/hudson/matrix/MatrixConfiguration.java
@@ -290,7 +290,6 @@ public class MatrixConfiguration extends Project<MatrixConfiguration,MatrixRun> 
             // Could happen if the parent started but Jenkins was restarted while the children were still in the queue.
             // In this case we simply guess that the last build of the parent is what triggered this configuration.
             // If MatrixProject.concurrentBuild, that is not necessarily correct.
-            // TODO would be better to have ParentBuildAction record a nontransient MatrixBuild.id so we could reliably recover it.
             lb = getParent().getLastBuild();
             if (lb == null) {
                 LOGGER.log(Level.WARNING, "cannot start a build of {0} since its parent has no builds at all", getFullName());

--- a/src/main/java/hudson/matrix/MatrixConfiguration.java
+++ b/src/main/java/hudson/matrix/MatrixConfiguration.java
@@ -504,10 +504,8 @@ public class MatrixConfiguration extends Project<MatrixConfiguration,MatrixRun> 
             final Executor currentExecutor = Executor.currentExecutor();
             if (currentExecutor != null) {
                 parent = (MatrixBuild) currentExecutor.getCurrentExecutable();
-                number = parent.getNumber();
-            } else {
-                number = null;
             }
+            number = parent == null ? null : parent.getNumber();
         }
 
         public boolean shouldSchedule(List<Action> actions) {

--- a/src/main/java/hudson/matrix/MatrixProject.java
+++ b/src/main/java/hudson/matrix/MatrixProject.java
@@ -879,7 +879,7 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
             MatrixConfiguration item = getItem(token);
             if(item!=null)
             return item;
-        } catch (IllegalArgumentException _) {
+        } catch (IllegalArgumentException ex) {
             // failed to parse the token as Combination. Must be something else
         }
         return super.getDynamic(token,req,rsp);

--- a/src/test/java/hudson/matrix/RestartTest.java
+++ b/src/test/java/hudson/matrix/RestartTest.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.matrix;
+
+import hudson.model.Label;
+import hudson.model.Queue;
+import hudson.model.Result;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author ogondza.
+ */
+public class RestartTest {
+
+    @Rule
+    public RestartableJenkinsRule j = new RestartableJenkinsRule();
+
+    private MatrixProject project;
+
+    @Test
+    public void resumeAllCombinations() throws Exception {
+        j.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                project = j.j.createMatrixProject("p");
+                project.setConcurrentBuild(true);
+                project.setAxes(new AxisList(new LabelAxis("labels", Arrays.asList("foo", "bar"))));
+
+                MatrixBuild parent = project.scheduleBuild2(0).waitForStart();
+                assertTrue(parent.isBuilding());
+                parent = project.scheduleBuild2(0).waitForStart();
+                assertTrue(parent.isBuilding());
+                Thread.sleep(1000);
+
+                assertThat(j.j.jenkins.getQueue().getItems(), Matchers.<Queue.Item>arrayWithSize(4));
+            }
+        });
+        j.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                MatrixBuild p1 = project.getBuildByNumber(1);
+                j.j.assertBuildStatus(Result.FAILURE, p1);
+                MatrixBuild p2 = project.getBuildByNumber(1);
+                j.j.assertBuildStatus(Result.FAILURE, p2);
+
+                j.j.createOnlineSlave(Label.get("foo"));
+                j.j.createOnlineSlave(Label.get("bar"));
+                j.j.waitUntilNoActivity();
+
+                assertThat(p1.getExactRuns(), Matchers.<MatrixRun>iterableWithSize(2));
+                for (MatrixRun run : p1.getExactRuns()) {
+                    j.j.assertBuildStatus(Result.SUCCESS, run);
+                }
+                assertThat(p2.getExactRuns(), Matchers.<MatrixRun>iterableWithSize(2));
+                for (MatrixRun run : p2.getExactRuns()) {
+                    j.j.assertBuildStatus(Result.SUCCESS, run);
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
```
Feb 28, 2017 8:59:56 AM hudson.matrix.MatrixConfiguration newBuild
WARNING: guessing that the correct build of PROJECT_ID is #19
Feb 28, 2017 8:59:56 AM hudson.model.Executor run
SEVERE: Unexpected executor death
java.lang.IllegalStateException: PROJECT_PATH/builds/19 already existed; will not overwite with PROJECT_ID #19
	at hudson.model.RunMap.put(RunMap.java:187)
	at hudson.matrix.MatrixConfiguration.newBuild(MatrixConfiguration.java:296)
	at hudson.matrix.MatrixConfiguration.newBuild(MatrixConfiguration.java:75)
	at hudson.model.AbstractProject.createExecutable(AbstractProject.java:1209)
	at hudson.model.AbstractProject.createExecutable(AbstractProject.java:144)
	at hudson.model.Executor$1.call(Executor.java:362)
	at hudson.model.Executor$1.call(Executor.java:344)
	at hudson.model.Queue._withLock(Queue.java:1348)
	at hudson.model.Queue.withLock(Queue.java:1213)
	at hudson.model.Executor.run(Executor.java:344)
```