### PR TITLE
Argument passed to createVariableResolver() must never be null.

### DIFF
--- a/src/main/java/hudson/matrix/FilterScript.java
+++ b/src/main/java/hudson/matrix/FilterScript.java
@@ -94,7 +94,7 @@ class FilterScript {
         for (final ParameterValue pv: parameters) {
             if (pv == null) continue;
             final String name = pv.getName();
-            final String value = pv.createVariableResolver(null).resolve(name);
+            final String value = pv.createVariableResolver(execution.getBuild()).resolve(name);
             binding.setVariable(name, value);
         }
 


### PR DESCRIPTION
This fixes a crash caused by passing a Credentials parameter to a Matrix build.