### PR TITLE
[JENKINS-44444] Matrix-project is failing the PCT

### DIFF
--- a/src/test/resources/hudson/matrix/runMatrix_1653.xml
+++ b/src/test/resources/hudson/matrix/runMatrix_1653.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<matrix-run>
+  <actions>
+    <hudson.model.CauseAction>
+      <causeBag class="linked-hash-map">
+        <entry>
+          <hudson.model.Cause_-UserIdCause>
+            <userId>admin</userId>
+          </hudson.model.Cause_-UserIdCause>
+          <int>1</int>
+        </entry>
+      </causeBag>
+    </hudson.model.CauseAction>
+    <jenkins.model.InterruptedBuildAction>
+      <causes class="com.google.common.collect.SingletonImmutableList" resolves-to="com.google.common.collect.ImmutableList$SerializedForm">
+        <elements>
+          <jenkins.model.CauseOfInterruption_-UserInterruption>
+            <user>auser</user>
+          </jenkins.model.CauseOfInterruption_-UserInterruption>
+        </elements>
+      </causes>
+    </jenkins.model.InterruptedBuildAction>
+  </actions>
+  <number>8</number>
+  <result>ABORTED</result>
+  <duration>3253844</duration>
+  <charset>windows-1252</charset>
+  <keepLog>false</keepLog>
+  <builtOn>amachine</builtOn>
+  <workspace>C:\jenkins\slave\workspace\MatrixProject\blah\blah\blah</workspace>
+  <hudsonVersion>1.427</hudsonVersion>
+  <culprits>
+    <string>auser</string>
+  </culprits>
+</matrix-run>


### PR DESCRIPTION
[JENKINS-44444](https://issues.jenkins-ci.org/browse/JENKINS-44444)

Make the test compatible with core >=1.653

By conditionally use a xml file that does not fire the OldDataMonitor on cores 1.653+

@reviewbybees 