### PR TITLE
Allow MatrixAggregatable to be registered as an (optional) extension

### DIFF
--- a/src/main/java/hudson/matrix/MatrixAggregatable.java
+++ b/src/main/java/hudson/matrix/MatrixAggregatable.java
@@ -23,6 +23,7 @@
  */
 package hudson.matrix;
 
+import hudson.Extension;
 import hudson.model.JobProperty;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.Publisher;
@@ -33,7 +34,7 @@ import hudson.model.BuildListener;
 /**
  * {@link Publisher}, {@link JobProperty}, {@link BuildWrapper} can optionally implement this interface
  * to perform result aggregation across {@link MatrixRun}.
- *
+ * <p>You may also register singleton instances of this as {@link Extension}s.
  * <p>
  * This is useful for example to aggregate all the test results
  * in {@link MatrixRun} into a single table/graph.

--- a/src/main/java/hudson/matrix/MatrixAggregatable.java
+++ b/src/main/java/hudson/matrix/MatrixAggregatable.java
@@ -34,10 +34,15 @@ import hudson.model.BuildListener;
 /**
  * {@link Publisher}, {@link JobProperty}, {@link BuildWrapper} can optionally implement this interface
  * to perform result aggregation across {@link MatrixRun}.
- * <p>You may also register singleton instances of this as {@link Extension}s.
+ *
  * <p>
  * This is useful for example to aggregate all the test results
  * in {@link MatrixRun} into a single table/graph.
+ *
+ * <p>
+ * You may also register singleton implementations of this interface as {@link Extension}s.
+ * Rather than forcing publishers and the like to implement this interface,
+ * the singleton can perform any logic it needs for result aggregation on a given build.
  *
  * @author Kohsuke Kawaguchi
  * @since 1.115

--- a/src/main/java/hudson/matrix/MatrixBuild.java
+++ b/src/main/java/hudson/matrix/MatrixBuild.java
@@ -25,6 +25,7 @@
 package hudson.matrix;
 
 import hudson.AbortException;
+import hudson.ExtensionList;
 import hudson.Functions;
 import hudson.Util;
 import hudson.console.ModelHyperlinkNote;
@@ -354,6 +355,7 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
             listUpAggregators(p.getPublishers().values());
             listUpAggregators(p.getProperties().values());
             listUpAggregators(p.getBuildWrappers().values());
+            listUpAggregators(ExtensionList.lookup(MatrixAggregatable.class));
 
             // rebuild project configuration
             MatrixProject.RunConfiguration config = p.getRunConfiguration(this);


### PR DESCRIPTION
This allows you to stop using `implements MatrixAggregatable` on publishers, which forces a hard dep on this plugin, and start using an optional extension.

@reviewbybees