### PR TITLE
[JENKINS-49201] Preventing errors when the "doDelete" form is submitted in test execution

### DIFF
--- a/src/test/java/hudson/matrix/MatrixProjectTest.java
+++ b/src/test/java/hudson/matrix/MatrixProjectTest.java
@@ -587,7 +587,7 @@ public class MatrixProjectTest {
 
         assertThat(deletePage.getWebResponse().getContentAsString(), containsString("Warning: #3 depends on this."));
 
-        j.submit(deletePage.getForms().get(1));
+        j.submit(deletePage.getForms().get(deletePage.getForms().size() - 1));
         assertEquals(2, p.getBuilds().size());
 
         // Code delete
@@ -622,7 +622,7 @@ public class MatrixProjectTest {
 
         assertThat(deletePage.getWebResponse().getContentAsString(), containsString("Warning: #3 depends on this."));
 
-        j.submit(deletePage.getForms().get(1));
+        j.submit(deletePage.getForms().get(deletePage.getForms().size() - 1));
         assertEquals(1, c.getBuilds().size());
 
         // Code delete


### PR DESCRIPTION
See [JENKINS-49201](https://issues.jenkins-ci.org/browse/JENKINS-49201)

`MatrixProjectTest#deletedLockedChildrenBuild` and `MatrixProjectTest#deletedLockedParentBuild` try to submit the "doDelete" action form. However, when these tests are executed forcing a newer jenkins-core version (via PCT for example), they fail since there are more than 2 forms and the "doDelete" action form is still the last one.

@olivergondza @reviewbybees 