### PR TITLE
Fix build on Java11 because of PowerMock

### DIFF
--- a/src/test/java/hudson/matrix/CombinationFilterUsingBuildParamsTest.java
+++ b/src/test/java/hudson/matrix/CombinationFilterUsingBuildParamsTest.java
@@ -61,6 +61,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.verification.VerificationMode;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -71,6 +72,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({MatrixBuildListener.class, MatrixProject.class, AbstractItem.class, Whitelist.class})
+@PowerMockIgnore({"javax.xml.*"})
 public class CombinationFilterUsingBuildParamsTest {
 
     /**


### PR DESCRIPTION
PCT fails with:

```
...
	at org.powermock.modules.junit4.common.internal.impl.AbstractCommonPowerMockRunner.run(AbstractCommonPowerMockRunner.java:57)
	at org.powermock.modules.junit4.PowerMockRunner.run(PowerMockRunner.java:59)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:273)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:377)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:138)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:465)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:451)
Caused by: com.thoughtworks.xstream.InitializationException: Could not instantiate converter : com.thoughtworks.xstream.converters.extended.DurationConverter : null
	at com.thoughtworks.xstream.XStream.registerConverterDynamically(XStream.java:904)
	at com.thoughtworks.xstream.XStream.setupConverters(XStream.java:867)
	at com.thoughtworks.xstream.XStream.<init>(XStream.java:574)
	at com.thoughtworks.xstream.XStream.<init>(XStream.java:496)
	at com.thoughtworks.xstream.XStream.<init>(XStream.java:465)
	at com.thoughtworks.xstream.XStream.<init>(XStream.java:411)
	at com.thoughtworks.xstream.XStream.<init>(XStream.java:378)
	at hudson.util.XStream2.<init>(XStream2.java:113)
	at hudson.model.Run.<clinit>(Run.java:2505)
	... 45 more
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at com.thoughtworks.xstream.XStream.registerConverterDynamically(XStream.java:897)
	... 53 more
Caused by: java.lang.IllegalAccessError: class javax.xml.datatype.FactoryFinder (in unnamed module @0x2be9add0) cannot access class jdk.xml.internal.SecuritySupport (in module java.xml) because module java.xml does not export jdk.xml.internal to unnamed module @0x2be9add0
	at javax.xml.datatype.FactoryFinder.<clinit>(FactoryFinder.java:70)
	at javax.xml.datatype.DatatypeFactory.newInstance(DatatypeFactory.java:169)
	at com.thoughtworks.xstream.converters.extended.DurationConverter$1.getFactory(DurationConverter.java:39)
	at com.thoughtworks.xstream.converters.extended.DurationConverter.<init>(DurationConverter.java:36)
	... 58 more
```

In: 

- hudson.matrix.CombinationFilterUsingBuildParamsTest.testCombinationFilterV09
- hudson.matrix.CombinationFilterUsingBuildParamsTest.testCombinationFilterV1
- hudson.matrix.CombinationFilterUsingBuildParamsTest.testCombinationFilterV2
- hudson.matrix.CombinationFilterUsingBuildParamsTest.testCombinationFilterV3
- hudson.matrix.CombinationFilterUsingBuildParamsTest.reproduceTouchstoneRegression
- hudson.matrix.CombinationFilterUsingBuildParamsTest.testCombinationFilterV01

@varyvol @alecharp @rsandell @bmunozm @raul-arabaolaza @amuniz @jglick