### PR TITLE
Update parent POM

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.2</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(useAci: true)

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,15 @@
         <relativePath />
     </parent>
     <artifactId>matrix-project</artifactId>
-    <version>1.18-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Matrix Project Plugin</name>
     <description>Multi-configuration (matrix) project type.</description>
     <url>https://github.com/jenkinsci/matrix-project-plugin</url>
     <properties>
+      <revision>1.18</revision>
+      <changelist>-SNAPSHOT</changelist>
+      <gitHubRepo>jenkinsci/matrix-project-plugin</gitHubRepo>
       <jenkins.version>2.164.3</jenkins.version>
       <java.level>8</java.level>
       <spotbugs.skip>true</spotbugs.skip> <!-- Clean up redundant null check warnings and re-enable after SECURITY-1339 is released -->
@@ -24,11 +27,11 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
-  </scm>
+        <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+        <tag>${scmTag}</tag>
+    </scm>
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.2</version>
+        <version>4.8</version>
         <relativePath />
     </parent>
     <artifactId>matrix-project</artifactId>


### PR DESCRIPTION
Compatibility with https://github.com/jenkinsci/jenkins/pull/4944 in PCT. https://github.com/jenkinsci/jenkins/pull/4944/commits/b45ffbceb4f5cfa1dd91e1ff7ba7f57e8639b4da only covers the common case that an inner `TestBuilder` is saved to one list; however in https://github.com/jenkinsci/matrix-project-plugin/blob/32aea35d4f06c810f7c11d3dc0d599f4af91a097/src/test/java/hudson/matrix/MatrixProjectTest.java#L683-L689 the first save works with only a warning but the second fails, and there is no known way to detect that the error in the second save should be ignored.
