### PR TITLE
[JENKINS-37292] Update default nextBuildBumber to avoid warning on load

### DIFF
--- a/src/main/java/hudson/matrix/MatrixConfiguration.java
+++ b/src/main/java/hudson/matrix/MatrixConfiguration.java
@@ -203,7 +203,7 @@ public class MatrixConfiguration extends Project<MatrixConfiguration,MatrixRun> 
     public int getNextBuildNumber() {
         MatrixBuild lcb = getParent().getLastCompletedBuild();
         if (lcb == null) {
-            return 0;
+            return 1;
         }
         int n = lcb.getNumber() + 1;
         MatrixRun lb = getLastBuild();

--- a/src/test/java/hudson/matrix/MatrixConfigurationTest.java
+++ b/src/test/java/hudson/matrix/MatrixConfigurationTest.java
@@ -23,8 +23,16 @@
  */
 package hudson.matrix;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -100,5 +108,21 @@ public class MatrixConfigurationTest {
         assertEquals("a&&b&&b", combinedP.getItem("expr=a&&b,label=b").getAssignedLabel().toString());
         assertEquals("a||b&&a", combinedP.getItem("expr=a||b,label=a").getAssignedLabel().toString());
         assertEquals("a||b&&b", combinedP.getItem("expr=a||b,label=b").getAssignedLabel().toString());
+    }
+
+    @Test
+    @Issue("JENKINS-27530")
+    public void nextBuildNumber() throws Exception {
+        MatrixProject p = r.createProject(MatrixProject.class);
+        p.setAxes(new AxisList(new Axis("a", "b")));
+        p.getItems().forEach( mc -> {
+            int size = (int)mc.getBuilds().stream().count();
+            assertThat(mc.getNextBuildNumber(), is(greaterThan(size)));
+        });
+        r.buildAndAssertSuccess(p);
+        p.getItems().forEach( mc -> {
+            int size = (int)mc.getBuilds().stream().count();
+            assertThat(mc.getNextBuildNumber(), is(greaterThan(size)));
+        });
     }
 }

--- a/src/test/java/hudson/matrix/MatrixConfigurationTest.java
+++ b/src/test/java/hudson/matrix/MatrixConfigurationTest.java
@@ -111,7 +111,7 @@ public class MatrixConfigurationTest {
     }
 
     @Test
-    @Issue("JENKINS-27530")
+    @Issue("JENKINS-37292")
     public void nextBuildNumber() throws Exception {
         MatrixProject p = r.createProject(MatrixProject.class);
         p.setAxes(new AxisList(new Axis("a", "b")));


### PR DESCRIPTION
For context see jenkinsci/jenkins#5139
This has also been manually verified to not show the warning.
A test has been added to ensure the next number is always greater than the number of builds.