### PR TITLE
(retry-scheduling) Retry logic when scheduling is not accepted

### DIFF
--- a/src/test/java/hudson/matrix/CombinationFilterUsingBuildParamsTest.java
+++ b/src/test/java/hudson/matrix/CombinationFilterUsingBuildParamsTest.java
@@ -23,33 +23,10 @@
  */
 package hudson.matrix;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import hudson.ExtensionList;
 import hudson.matrix.MatrixBuild.MatrixBuildExecution;
 import hudson.matrix.listeners.MatrixBuildListener;
-import hudson.model.AbstractItem;
-import hudson.model.BuildListener;
-import hudson.model.Cause;
-import hudson.model.ParametersAction;
-import hudson.model.Result;
-import hudson.model.Run;
-import hudson.model.StringParameterValue;
-
-import java.io.IOException;
-import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-
+import hudson.model.*;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.Whitelist;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.BlanketWhitelist;
@@ -64,6 +41,14 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.*;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.*;
 
 /**
  * Make sure that the combination filter schedules correct builds in correct order
@@ -270,6 +255,7 @@ public class CombinationFilterUsingBuildParamsTest {
         when(conf.getDisplayName()).thenReturn(axis);
         when(conf.getUrl()).thenReturn(axis);
         when(conf.getBuildByNumber(anyInt())).thenReturn(run);
+        when(conf.scheduleBuild(anyList(),any())).thenReturn(true);
 
         return conf;
     }


### PR DESCRIPTION
Before this change the call to scheduleBuild would run a jenkins.getQueue().schedule2() and return
the value of .isAccepted() but there was no logic around the case where it is not accepted.
We have seen instances in production where the console logs would print 'Triggering XYZ'
but that build would never make it to the queue, leading the code to then wait forever
for the completion of an inexisting build.
I assume queue contention when isAccepted() is false and that a retry will get around the
problem.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Tests were fixed because with the change they would run 5 times since there was no return value provided for scheduleBuild. I did not add a specific test for the for loop since this is boilerplate and .isAccepted() is Boolean and only really exercised in production.
