### PR TITLE
Remove java 8 from CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,6 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin(useAci: true)
+buildPlugin(useContainerAgent: true, configurations: [
+  [ platform: "linux", jdk: "11" ]
+])


### PR DESCRIPTION
Required due to https://github.com/jenkinsci/matrix-project-plugin/pull/104