### PR TITLE
Refresh plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.43.1</version>
+        <version>4.60</version>
         <relativePath />
     </parent>
     <artifactId>matrix-project</artifactId>
@@ -15,7 +15,7 @@
     <properties>
       <changelist>999999-SNAPSHOT</changelist>
       <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-      <jenkins.version>2.359</jenkins.version>
+      <jenkins.version>2.361.4</jenkins.version>
       <spotbugs.skip>true</spotbugs.skip> <!-- Clean up redundant null check warnings and re-enable after SECURITY-1339 is released -->
     </properties>
     <licenses>
@@ -74,18 +74,13 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.346.x</artifactId>
-                <version>1478.v81d3dc4f9a_43</version>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>2000.v4677a_6e0ffea</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
it's required for https://github.com/jenkinsci/jenkins/pull/7781 so that tests continue passing in this plugin and in bom, currently failing in https://github.com/jenkinsci/bom/pull/1968.

can this be released please?