### PR TITLE
style(MatrixTestResult): Increase column width for duration

### DIFF
--- a/src/main/resources/hudson/tasks/test/MatrixTestResult/index.jelly
+++ b/src/main/resources/hudson/tasks/test/MatrixTestResult/index.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
       <table class="pane sortable bigtable">
         <tr>
           <td class="pane-header">Configuration Name</td>
-          <td class="pane-header" style="width:4em;text-align:right">Duration</td>
+          <td class="pane-header" style="width:6em;text-align:right">Duration</td>
           <td class="pane-header" style="width:4em;text-align:right">All</td>
           <td class="pane-header" style="width:4em;text-align:right">Failed</td>
           <td class="pane-header" style="width:4em;text-align:right">Skipped</td>


### PR DESCRIPTION
`4em` is too narrow for texts like `6 hr 17 min` to fit into: It is shown on two lines as:
> 6 hr 17
> min

The German translation is even worse, which spans 4 lines:
> 6
> Stunden
> 17
> Minuten

which make the table take up too much space.

<!-- Please describe your pull request here. -->

### Testing done
```console
# jar xf matrix-project.jar hudson/tasks/test/MatrixTestResult/index.jelly
# vi  hudson/tasks/test/MatrixTestResult/index.jelly
# jar uf matrix-project.jar hudson/tasks/test/MatrixTestResult/index.jelly
# restart jenkins
```
![jenkins-old](https://github.com/jenkinsci/matrix-project-plugin/assets/965550/6e5abcfc-b1da-4549-beba-58f8f5994e7f)
![jenkins-new](https://github.com/jenkinsci/matrix-project-plugin/assets/965550/e06f04cf-b385-4799-a455-67adabfc0cfb)

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```