### PR TITLE
Use @Deprecated annotation to silence compiler warnings

### DIFF
--- a/src/main/java/hudson/matrix/Axis.java
+++ b/src/main/java/hudson/matrix/Axis.java
@@ -63,6 +63,7 @@ public class Axis extends AbstractDescribableImpl<Axis> implements Comparable<Ax
      * @deprecated as of 1.373
      *      Use {@link #getName()}
      */
+    @Deprecated
     @Restricted(NoExternalUse.class)
     public final String name;
 
@@ -72,6 +73,7 @@ public class Axis extends AbstractDescribableImpl<Axis> implements Comparable<Ax
      * @deprecated as of 1.373
      *      Use {@link #getValues()}
      */
+    @Deprecated
     @Restricted(NoExternalUse.class)
     @RestrictedSince("1.463")
     public final List<String> values;
@@ -106,6 +108,7 @@ public class Axis extends AbstractDescribableImpl<Axis> implements Comparable<Ax
      * @deprecated as of 1.373
      *      System vs user difference are generalized into extension point.
      */
+    @Deprecated
     public boolean isSystem() {
         return false;
     }

--- a/src/main/java/hudson/matrix/Combination.java
+++ b/src/main/java/hudson/matrix/Combination.java
@@ -97,6 +97,7 @@ public final class Combination extends TreeMap<String,String> implements Compara
      * @deprecated as of 1.528
      *      Use {@link FilterScript#apply(hudson.matrix.MatrixBuild.MatrixBuildExecution, Combination)}
      */
+    @Deprecated
     public boolean evalGroovyExpression(AxisList axes, String expression, Binding binding) {
         return FilterScript.parse(expression).apply(axes, this, binding);
     }

--- a/src/main/java/hudson/matrix/LinkedLogRotator.java
+++ b/src/main/java/hudson/matrix/LinkedLogRotator.java
@@ -51,6 +51,7 @@ final class LinkedLogRotator extends LogRotator {
      * @deprecated since 1.369
      *     Use {@link #LinkedLogRotator(int, int)}
      */
+    @Deprecated
     LinkedLogRotator() {
         super(-1, -1, -1, -1);
     }

--- a/src/main/java/hudson/matrix/MatrixConfiguration.java
+++ b/src/main/java/hudson/matrix/MatrixConfiguration.java
@@ -426,6 +426,7 @@ public class MatrixConfiguration extends Project<MatrixConfiguration,MatrixRun> 
      * @deprecated
      *      Not supported.
      */
+    @Deprecated
     @Override
     public void setJDK(JDK jdk) throws IOException {
         throw new UnsupportedOperationException();
@@ -435,6 +436,7 @@ public class MatrixConfiguration extends Project<MatrixConfiguration,MatrixRun> 
      * @deprecated
      *      Value is controlled by {@link MatrixProject}.
      */
+    @Deprecated
     @Override
     public void setBuildDiscarder(BuildDiscarder logRotator) {
         throw new UnsupportedOperationException();
@@ -467,6 +469,7 @@ public class MatrixConfiguration extends Project<MatrixConfiguration,MatrixRun> 
 	 * @deprecated
 	 *    Use {@link #scheduleBuild(ParametersAction, Cause)}.  Since 1.283
 	 */
+    @Deprecated
     public boolean scheduleBuild(ParametersAction parameters) {
         return scheduleBuild(parameters, new Cause.UserIdCause());
     }
@@ -478,6 +481,7 @@ public class MatrixConfiguration extends Project<MatrixConfiguration,MatrixRun> 
      * @deprecated
 	 *    Use {@link #scheduleBuild(List, Cause)}.  Since 1.480
      */
+    @Deprecated
     public boolean scheduleBuild(ParametersAction parameters, Cause c) {
         return scheduleBuild(Collections.singletonList(parameters), c);
     }

--- a/src/main/java/hudson/matrix/MatrixExecutionStrategy.java
+++ b/src/main/java/hudson/matrix/MatrixExecutionStrategy.java
@@ -49,6 +49,7 @@ public abstract class MatrixExecutionStrategy extends AbstractDescribableImpl<Ma
      * @deprecated
      *      Override {@link #run(MatrixBuild.MatrixBuildExecution)}
      */
+    @Deprecated
     public Result run(MatrixBuild build, List<MatrixAggregator> aggregators, BuildListener listener) throws InterruptedException, IOException {
         throw new UnsupportedOperationException(getClass()+" needs to override run(MatrixBuildExecution)");
     }


### PR DESCRIPTION
## Use `@Deprecated` annotation to silence compiler warnings

The methods are already listed as deprecated in their Javadoc.  Let's silence the compiler warnings by annotating them as deprecated.

### Testing done

Confirmed that compiler warning is visible before this change and is removed after this change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
