### PR TITLE
Reduce `javax.servlet.ServletException` footprint

### DIFF
--- a/src/main/java/hudson/matrix/MatrixConfiguration.java
+++ b/src/main/java/hudson/matrix/MatrixConfiguration.java
@@ -66,7 +66,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 
 import org.kohsuke.accmod.Restricted;
@@ -144,7 +143,7 @@ public class MatrixConfiguration extends Project<MatrixConfiguration,MatrixRun> 
     }
     
     @Override
-    public final HttpResponse doDisable() throws IOException, ServletException {
+    public final HttpResponse doDisable() throws IOException {
         return HttpResponses.errorWithoutStack(405, Messages.MatrixConfiguration_DisableNotAllowed());
     }
     


### PR DESCRIPTION
Not declaring this unnecessary `throws` will make it easier to adapt in the future if/when the return type of the super method changes in Jenkins core to adopt EE 9.

### Testing done

`mvn clean verify`