### PR TITLE
fix: link on icons in Configuration matrix table

### DIFF
--- a/src/main/resources/hudson/matrix/MatrixBuild/ajaxMatrix.jelly
+++ b/src/main/resources/hudson/matrix/MatrixBuild/ajaxMatrix.jelly
@@ -36,8 +36,8 @@ THE SOFTWARE.
           ${%Not run}
         </j:when>
         <j:otherwise>
-          <l:icon src="symbol-status-${b.iconColor.iconName}" class="icon-md" tooltip="${h.xmlEscape(p.tooltip)} ${it.number!=b.number?(it.isBuilding()?'- pending' : '- skipped'):''}" alt="${p.tooltip}" style="vertical-align: middle; ${it.number!=b.number?'opacity:0.5':''}"/>
           <a href="${p.nearestRunUrl}" class="model-link inside">
+          <l:icon src="symbol-status-${b.iconColor.iconName}" class="icon-md" tooltip="${h.xmlEscape(p.tooltip)} ${it.number!=b.number?(it.isBuilding()?'- pending' : '- skipped'):''}" alt="${p.tooltip}" style="vertical-align: middle; ${it.number!=b.number?'opacity:0.5':''}"/>
             <j:if test="${empty(o.x) and empty(o.y)}">
               ${p.combination.toString(o.z)}
             </j:if>

--- a/src/main/resources/hudson/matrix/MatrixProject/ajaxMatrix.jelly
+++ b/src/main/resources/hudson/matrix/MatrixProject/ajaxMatrix.jelly
@@ -35,8 +35,8 @@ THE SOFTWARE.
           ${%Not configured}
         </j:when>
         <j:otherwise>
-          <l:icon src="symbol-status-${p.iconColor.iconName}" class="icon-md" tooltip="${p.iconColor.description}" alt="${p.iconColor.description}"/>
           <a href="${p.shortUrl}" class="model-link inside" style="vertical-align: middle">
+          <l:icon src="symbol-status-${p.iconColor.iconName}" class="icon-md" tooltip="${p.iconColor.description}" alt="${p.iconColor.description}"/>
             <j:if test="${empty(o.x) and empty(o.y)}">
               ${p.combination.toString(o.z)}
             </j:if>


### PR DESCRIPTION
In a matrix project/build with more than one axis, the Configuration Matrix is presented in a table where cells only contain the status icon. The previous change which moves the icon out of the \<a href\> makes it impossible to click on a cell to get to its build page. Restore the previous behavior to make the cells clickable and allow the use of the pop-up menu.
