### PR TITLE
Remove usage of deprecated EE 8 method

### DIFF
--- a/src/main/resources/lib/hudson/matrix-project/matrix.jelly
+++ b/src/main/resources/lib/hudson/matrix-project/matrix.jelly
@@ -98,7 +98,7 @@ THE SOFTWARE.
         </table>
       </j:otherwise>
     </j:choose>
-    <j:if test="${ajax==null and attrs.autoRefresh and !h.isAutoRefresh(request)}">
+    <j:if test="${ajax==null and attrs.autoRefresh}">
       <st:adjunct includes="lib.hudson.matrix-project.matrix-resources"/>
     </j:if>
   </div>


### PR DESCRIPTION
As of https://github.com/jenkinsci/jenkins/pull/4503 this always returned `false` anyway. There is no EE 9 replacement.