### PR TITLE
Enable test coverage reporting on ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,6 @@
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 buildPlugin(useContainerAgent: true, configurations: [
-  [ platform: "windows", jdk: "17" ],
   [ platform: "linux", jdk: "21" ],
+  [ platform: "windows", jdk: "17" ],
 ])


### PR DESCRIPTION
## Enable test coverage reporting on ci.jenkins.io

The `buildPlugin` step needs the first configuration to be a Linux configuration or it won't publish coverage results.

### Testing done

* [x] [master branch](https://ci.jenkins.io/job/Plugins/job/matrix-project-plugin/job/master/) does not include a coverage report prior to this change.
* [x] Confirmed that [this pull request](https://ci.jenkins.io/job/Plugins/job/matrix-project-plugin/job/PR-283/2/) includes a [coverage report](https://ci.jenkins.io/job/Plugins/job/matrix-project-plugin/job/PR-283/lastBuild/coverage/).

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

Should be labeled `internal` since it is not changing any user-visible functionality.