### PR TITLE
Fix wrapping for single-axis

### DIFF
--- a/src/main/resources/lib/hudson/matrix-project/matrix-styles.css
+++ b/src/main/resources/lib/hudson/matrix-project/matrix-styles.css
@@ -40,8 +40,9 @@
 
 .mp-single-axis {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.25rem;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 .mp-cell:last-of-type {


### PR DESCRIPTION
use flex-wrap to avoid that wrapping happens within a single configuration
Regression from #289

Before:
<img width="1117" height="227" alt="image" src="https://github.com/user-attachments/assets/7e745229-714b-4572-ab80-02887bfc16c7" />

After: 
<img width="804" height="142" alt="image" src="https://github.com/user-attachments/assets/2e592924-f7c3-4b8d-8ed3-d40a892f6ada" />

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
