### PR TITLE
[JENKINS-45050] Can only sort execution order when running sequential…

### DIFF
--- a/src/main/resources/hudson/matrix/DefaultMatrixExecutionStrategyImpl/config.groovy
+++ b/src/main/resources/hudson/matrix/DefaultMatrixExecutionStrategyImpl/config.groovy
@@ -12,7 +12,8 @@ if (MatrixConfigurationSorterDescriptor.all().size()>1) {
     f.dropdownDescriptorSelector(title:_("Execution order of builds"), field:"sorter")
 }
 
-f.optionalBlock (field:"runSequentially", title:_("Run each configuration sequentially"), inline:true) {
+f.entry(title:_("Run each configuration sequentially"), field:"runSequentially") {
+    f.checkbox()
 }
 
 f.optionalBlock (field:"hasTouchStoneCombinationFilter", title:_("Execute touchstone builds first"), inline:true) {

--- a/src/main/resources/hudson/matrix/DefaultMatrixExecutionStrategyImpl/config.groovy
+++ b/src/main/resources/hudson/matrix/DefaultMatrixExecutionStrategyImpl/config.groovy
@@ -5,10 +5,14 @@ import hudson.model.Result;
 
 def f = namespace(lib.FormTagLib)
 
+// Execution order applies to both parallel and sequential scheduling (see DefaultMatrixExecutionStrategyImpl.run()).
+// Keeping the sorter inside the sequential optional block hid it when parallel mode was selected and could drop the
+// sorter on save when sequential was unchecked.
+if (MatrixConfigurationSorterDescriptor.all().size()>1) {
+    f.dropdownDescriptorSelector(title:_("Execution order of builds"), field:"sorter")
+}
+
 f.optionalBlock (field:"runSequentially", title:_("Run each configuration sequentially"), inline:true) {
-    if (MatrixConfigurationSorterDescriptor.all().size()>1) {
-        f.dropdownDescriptorSelector(title:_("Execution order of builds"), field:"sorter")
-    }
 }
 
 f.optionalBlock (field:"hasTouchStoneCombinationFilter", title:_("Execute touchstone builds first"), inline:true) {


### PR DESCRIPTION
…ly #687

Decoupled matrix configuration sorting from sequential execution in the Matrix Project Plugin.

Previously, custom MatrixConfigurationSorter implementations were only applied when the "Run each configuration sequentially" option was enabled.

As a result, there was no way to control the execution order of matrix configurations while still running them in parallel.

What was fixed - Enabled matrix configuration sorting independently from sequential execution.

### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

