### PR TITLE
[762] Add a delay between scheduling Matrix configurations in Jenkins

### DIFF
--- a/src/main/java/hudson/matrix/DefaultMatrixExecutionStrategyImpl.java
+++ b/src/main/java/hudson/matrix/DefaultMatrixExecutionStrategyImpl.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.TreeSet;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * {@link MatrixExecutionStrategy} that captures historical behavior.
@@ -54,23 +55,54 @@ public class DefaultMatrixExecutionStrategyImpl extends MatrixExecutionStrategy 
 
     private volatile MatrixConfigurationSorter sorter;
 
+    /**
+     * When {@link #isRunSequentially()} is false, sleep this many milliseconds before enqueueing each configuration
+     * after the first (including between the last touchstone and the first remaining configuration). Zero disables.
+     */
+    private volatile int scheduleDelayMillis;
+
     @DataBoundConstructor
     public DefaultMatrixExecutionStrategyImpl(Boolean runSequentially, boolean hasTouchStoneCombinationFilter, String touchStoneCombinationFilter, Result touchStoneResultCondition, MatrixConfigurationSorter sorter) {
         this(runSequentially!=null ? runSequentially : false,
             hasTouchStoneCombinationFilter ? touchStoneCombinationFilter : null,
             hasTouchStoneCombinationFilter ? touchStoneResultCondition : null,
+            0,
             sorter);
     }
 
     public DefaultMatrixExecutionStrategyImpl(boolean runSequentially, String touchStoneCombinationFilter, Result touchStoneResultCondition, MatrixConfigurationSorter sorter) {
+        this(runSequentially, touchStoneCombinationFilter, touchStoneResultCondition, 0, sorter);
+    }
+
+    public DefaultMatrixExecutionStrategyImpl(boolean runSequentially, String touchStoneCombinationFilter, Result touchStoneResultCondition, int scheduleDelayMillis, MatrixConfigurationSorter sorter) {
         this.runSequentially = runSequentially;
         this.touchStoneCombinationFilter = touchStoneCombinationFilter;
         this.touchStoneResultCondition = touchStoneResultCondition;
+        this.scheduleDelayMillis = Math.max(0, scheduleDelayMillis);
         this.sorter = sorter;
     }
 
     public DefaultMatrixExecutionStrategyImpl() {
-        this(false,false,null,null,null);
+        this(false, false, null, null, null);
+    }
+
+    /**
+     * Optional delay is not part of {@link DataBoundConstructor} so Stapler/XStream stay compatible
+     * with the historical 5-argument constructor shape (avoids subtle test/plugin loading issues).
+     */
+    @DataBoundSetter
+    public void setHasScheduleDelayBetweenChildBuilds(boolean has) {
+        if (!has) {
+            scheduleDelayMillis = 0;
+        }
+    }
+
+    @DataBoundSetter
+    public void setScheduleDelayMillis(Integer scheduleDelayMillis) {
+        if (scheduleDelayMillis == null) {
+            return;
+        }
+        this.scheduleDelayMillis = Math.max(0, scheduleDelayMillis);
     }
 
     public boolean getHasTouchStoneCombinationFilter() {
@@ -114,6 +146,18 @@ public class DefaultMatrixExecutionStrategyImpl extends MatrixExecutionStrategy 
         this.sorter = sorter;
     }
 
+    public int getScheduleDelayMillis() {
+        return scheduleDelayMillis;
+    }
+
+    public void setScheduleDelayMillis(int scheduleDelayMillis) {
+        this.scheduleDelayMillis = Math.max(0, scheduleDelayMillis);
+    }
+
+    public boolean getHasScheduleDelayBetweenChildBuilds() {
+        return scheduleDelayMillis > 0;
+    }
+
     @Override
     public Result run(MatrixBuildExecution execution) throws InterruptedException, IOException {
 
@@ -133,9 +177,10 @@ public class DefaultMatrixExecutionStrategyImpl extends MatrixExecutionStrategy 
             delayedConfigurations    = createTreeSet(delayedConfigurations, sorter);
         }
 
-        if(!runSequentially)
-            for(MatrixConfiguration c : touchStoneConfigurations)
-                scheduleConfigurationBuild(execution, c);
+        boolean parallelEnqueueStarted = false;
+        if (!runSequentially) {
+            parallelEnqueueStarted = scheduleConfigurationsInParallel(execution, touchStoneConfigurations, parallelEnqueueStarted);
+        }
 
         PrintStream logger = execution.getListener().getLogger();
 
@@ -154,9 +199,9 @@ public class DefaultMatrixExecutionStrategyImpl extends MatrixExecutionStrategy 
             return r;
         }
 
-        if(!runSequentially)
-            for(MatrixConfiguration c : delayedConfigurations)
-                scheduleConfigurationBuild(execution, c);
+        if (!runSequentially) {
+            scheduleConfigurationsInParallel(execution, delayedConfigurations, parallelEnqueueStarted);
+        }
 
         for (MatrixConfiguration c : delayedConfigurations) {
             if(runSequentially)
@@ -227,6 +272,26 @@ public class DefaultMatrixExecutionStrategyImpl extends MatrixExecutionStrategy 
         TreeSet<T> r = new TreeSet<T>(sorter);
         r.addAll(items);
         return r;
+    }
+
+    /**
+     * Enqueue configurations for parallel mode, optionally pausing between each {@link #scheduleConfigurationBuild}.
+     *
+     * @param afterPrevious {@code true} if at least one configuration was already enqueued in this matrix build
+     * @return {@code true} once any configuration from {@code configurations} was enqueued
+     */
+    private boolean scheduleConfigurationsInParallel(
+            MatrixBuildExecution execution,
+            Iterable<MatrixConfiguration> configurations,
+            boolean afterPrevious) throws InterruptedException {
+        for (MatrixConfiguration c : configurations) {
+            if (afterPrevious && scheduleDelayMillis > 0) {
+                Thread.sleep(scheduleDelayMillis);
+            }
+            scheduleConfigurationBuild(execution, c);
+            afterPrevious = true;
+        }
+        return afterPrevious;
     }
 
     /** Function to start schedule a single configuration

--- a/src/main/resources/hudson/matrix/DefaultMatrixExecutionStrategyImpl/config.groovy
+++ b/src/main/resources/hudson/matrix/DefaultMatrixExecutionStrategyImpl/config.groovy
@@ -11,6 +11,12 @@ f.optionalBlock (field:"runSequentially", title:_("Run each configuration sequen
     }
 }
 
+f.optionalBlock(field:"hasScheduleDelayBetweenChildBuilds", title:_("Add delay between scheduling each configuration (parallel mode only)"), inline:true) {
+    f.entry(title:_("Milliseconds between enqueueing each configuration"), field:"scheduleDelayMillis") {
+        f.textbox(default:"0")
+    }
+}
+
 f.optionalBlock (field:"hasTouchStoneCombinationFilter", title:_("Execute touchstone builds first"), inline:true) {
     // TODO: help="/help/matrix/touchstone.html">
     // TODO: move l10n from MatrixProject/configEntries.jelly

--- a/src/test/java/hudson/matrix/MatrixProjectTest.java
+++ b/src/test/java/hudson/matrix/MatrixProjectTest.java
@@ -328,6 +328,13 @@ public class MatrixProjectTest {
         p.setExecutionStrategy(before);
         j.configRoundtrip(p);
         j.assertEqualDataBoundBeans(p.getExecutionStrategy(), before);
+
+        before = new DefaultMatrixExecutionStrategyImpl(false, null, null, null);
+        before.setHasScheduleDelayBetweenChildBuilds(true);
+        before.setScheduleDelayMillis(150);
+        p.setExecutionStrategy(before);
+        j.configRoundtrip(p);
+        j.assertEqualDataBoundBeans(p.getExecutionStrategy(), before);
     }
 
     @Test


### PR DESCRIPTION
[<!-- Please describe your pull request here. -->](https://github.com/jenkinsci/matrix-project-plugin/issues/762)

Currently, all parallel configurations are scheduled simultaneously. This can lead to situations where Jenkins starts processing queued builds in an order different from the one specified in Execution order of builds.

Proposed solution: Implement the ability to configure a delay between scheduling configurations from a matrix into the Jenkins queue.

This setting would allow users to manually specify the delay interval between scheduling consecutive configurations.

Default value: 0
Unit: milis (or specify if needed)

This enhancement would help preserve the intended execution order and reduce unexpected build sequencing caused by Jenkins queue processing behavior.

### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
